### PR TITLE
Xgb domain type roundtrip

### DIFF
--- a/.github/issue-drafts/cpus-dosnow-libpaths.md
+++ b/.github/issue-drafts/cpus-dosnow-libpaths.md
@@ -1,0 +1,100 @@
+# `xgb(cpus > 1)` fails with "object '.doSnowGlobals' not found" when the library is not on the workers' path
+
+## Summary
+
+`xgb()` with `cpus > 1` aborts during the bootstrap:
+
+```
+Error in checkForRemoteErrors(lapply(cl, recvResult)) :
+  6 nodes produced errors; first error: object '.doSnowGlobals' not found
+```
+
+The cause is environmental rather than a logic error in povmap, but the failure
+mode is opaque and povmap can either prevent it or diagnose it. Filing so the
+behaviour is recorded.
+
+## Root cause
+
+`R/xgb.R:570-571`:
+
+```r
+cl <- parallel::makeCluster(cpus)
+doSNOW::registerDoSNOW(cl)
+```
+
+`parallel::makeCluster()` starts **PSOCK** workers, which are fresh R sessions.
+They inherit environment variables but **not** a `.libPaths()` set at runtime in
+the parent. If povmap and its dependencies live in a library added at runtime
+(`.libPaths(c(lib, .libPaths()))`, common under `renv`, a shared team library,
+or a non-default `R_LIBS` layout), the workers cannot see `doSNOW`.
+`registerDoSNOW()` then fails to initialise `.doSnowGlobals` on them, and the
+first `%dopar%` iteration reports the missing object rather than the missing
+package.
+
+Demonstrated directly:
+
+```r
+.libPaths(c("E:/David/R/lib-4.5.3", .libPaths()))
+cl <- parallel::makeCluster(2)
+parallel::clusterEvalQ(cl, .libPaths())
+#> [1] "G:/David/R/R-4.5.3/library"          # runtime path absent
+parallel::clusterEvalQ(cl, "doSNOW" %in% rownames(installed.packages()))
+#> [1] FALSE FALSE
+
+Sys.setenv(R_LIBS_USER = "E:/David/R/lib-4.5.3")   # env vars ARE inherited
+cl2 <- parallel::makeCluster(2)
+parallel::clusterEvalQ(cl2, "doSNOW" %in% rownames(installed.packages()))
+#> [1] TRUE TRUE
+doSNOW::registerDoSNOW(cl2)                        # succeeds
+```
+
+With `R_LIBS_USER` set, `xgb(cpus = 6, B = 100)` runs to completion.
+
+## Not platform-specific in principle, but Windows makes it certain
+
+PSOCK is the only cluster type on Windows, so the problem always applies there.
+On Linux/macOS the default is still PSOCK for `parallel::makeCluster()`, so the
+same failure occurs; a `type = "FORK"` cluster would inherit the parent's
+`.libPaths()` and mask it.
+
+## `megb()` is unaffected
+
+`megb()` and `megb_mse()` contain no cluster construction — no `makeCluster`,
+`registerDoSNOW`, `registerDoParallel` or `%dopar%`. The bug is confined to
+`xgb()`'s bootstrap.
+
+## Suggested fixes, in order of preference
+
+1. Propagate the parent's library path to the workers immediately after the
+   cluster is created, before `registerDoSNOW()`:
+   ```r
+   cl <- parallel::makeCluster(cpus)
+   parallel::clusterCall(cl, function(p) .libPaths(p), .libPaths())
+   doSNOW::registerDoSNOW(cl)
+   ```
+   Two lines, no new dependency, fixes every runtime-library layout.
+
+2. Failing that, check reachability and fail with a useful message:
+   ```r
+   if (!all(unlist(parallel::clusterEvalQ(cl, requireNamespace("doSNOW", quietly = TRUE))))) {
+     parallel::stopCluster(cl)
+     stop("cpus > 1 requires doSNOW on the workers' .libPaths(); ",
+          "set R_LIBS_USER or use cpus = 1.")
+   }
+   ```
+
+## Separate observation: `cpus > 1` can be much slower
+
+Measured on this workload (428,726 population sub-areas, 84,962 sample rows,
+1,122 domains, `nrounds = 100`):
+
+| B | cpus | wall |
+|---|------|------|
+| 100 | 1 | 17.5 s |
+| 100 | 6 | 56.0 s |
+
+The bootstrap itself is ~8 s of the 17.5 s; the rest is data preparation, which
+is not parallelised. Six worker sessions each loading povmap and its ~37
+imports costs more than the work they receive. Worth a note in `?xgb` that
+`cpus > 1` pays off only when `B` and the per-iteration cost are large enough to
+amortise worker startup.

--- a/R/xgb.R
+++ b/R/xgb.R
@@ -1148,7 +1148,19 @@ point_estim_xgb <- function(params, smp_X, smp_Y, smp_weight, pop_X, sub_domains
                                wts= collapse:::fsum(wt_sub_domains,g=sample[,fwk$domains]),
                                resid_domains=collapse:::fmean(resid_total,g=sample[,fwk$domains],w=wt_sub_domains))
 
-  sample_domains <- data.frame(sample_domains,rownames(sample_domains))
+  ## fmean(g=) names its result by group, so rownames() here is ALWAYS
+  ## character. Rebuilding the domain column from it and joining straight back
+  ## onto `sample` therefore fails whenever `domains` is numeric or a factor --
+  ## both of which the documentation explicitly permits ("The variable can be
+  ## numeric or a factor"). Restore the incoming type before the join.
+  .dom   <- rownames(sample_domains)
+  .proto <- sample[[fwk$domains]]
+  if (is.numeric(.proto)) {
+    .dom <- as.numeric(.dom)
+  } else if (is.factor(.proto)) {
+    .dom <- factor(.dom, levels = levels(.proto))
+  }
+  sample_domains <- data.frame(sample_domains, .dom)
   colnames(sample_domains)[ncol(sample_domains)] <- fwk$domains
   sample <- left_join(sample,sample_domains,by=fwk$domains)
 

--- a/R/xgb.R
+++ b/R/xgb.R
@@ -734,6 +734,15 @@ xgb <- function(fixed,
                                     # benchmark predictions to the collapsed simulated sample in probability space
                                     # First calculate weighted mean of sample to benchmark, for each benchmark_level
                                     B_sample_bm <- data.frame(sample_bm = collapse:::fmean(x=B_sample$sim_plus_area,g=B_sample[,benchmark_level],w=B_sample[,benchmark_weights]))
+                                    ## rownames() is character here too, but unlike the
+                                    ## domain round-trip at R/xgb.R:1156 this one is not a
+                                    ## latent join bug: its only consumer is the setNames()
+                                    ## call below, and names() are character by definition,
+                                    ## so restoring the caller's type would change nothing.
+                                    ## The left_join on benchmark_level that WOULD have
+                                    ## broken is commented out (see two lines down). Left
+                                    ## as-is deliberately; if that join is ever restored,
+                                    ## apply the same type restoration used at :1156.
                                     B_sample_bm[,benchmark_level] <- rownames(B_sample_bm)
 
                                     # (benchmark-target perturbation is applied post-loop in the main process)
@@ -1211,9 +1220,21 @@ point_estim_xgb <- function(params, smp_X, smp_Y, smp_weight, pop_X, sub_domains
   sub_pred_t$sim_t <- NULL
 
 
+  ## Return the domain identifier in the CALLER's type, not rownames()'s
+  ## character. The only consumer is the `%in%` filter at R/xgb.R:459, which
+  ## coerces and so does not error -- but as.character() on a numeric domain can
+  ## emit scientific notation (as.character(1e5) == "1e+05"), which would fail
+  ## to match silently. Cheap to make exact.
+  .dom_out <- rownames(sample_domains)
+  .proto_out <- sample[[fwk$domains]]
+  if (is.numeric(.proto_out)) {
+    .dom_out <- as.numeric(.dom_out)
+  } else if (is.factor(.proto_out)) {
+    .dom_out <- factor(.dom_out, levels = levels(.proto_out))
+  }
   return(list(predictions=MC_results,sub_predictions = sub_pred_t, model=xgb_fit,resid_sub_domains=resid_sub_domains,
               resid_domains=resid_domains, resid_total=resid_total,wt_sub_domains=wt_sub_domains,
-              wt_domains=sample_domains$wts,domains=rownames(sample_domains)))
+              wt_domains=sample_domains$wts,domains=.dom_out))
 }
 
 

--- a/tests/testthat/test_xgb_domain_types.R
+++ b/tests/testthat/test_xgb_domain_types.R
@@ -1,0 +1,70 @@
+## Regression test for the domain-type round-trip in xgb().
+##
+## ?xgb documents `domains` as "can be numeric or a factor". Before the fix,
+## point_estim_xgb() rebuilt the domain column from rownames() -- always
+## character -- and left_join()ed it straight back onto smp_data, so a numeric
+## or integer domain identifier raised:
+##   "Can't join `x$<domains>` with `y$<domains>` due to incompatible types."
+## The failure was in the point-estimate path, so it hit every call, not only
+## bootstrapped ones.
+
+make_toy <- function(domain_type = c("integer", "numeric", "character", "factor"),
+                     n_dom = 6L, n_sub = 4L, n_per = 5L, seed = 1L) {
+  domain_type <- match.arg(domain_type)
+  set.seed(seed)
+  pop <- expand.grid(d = seq_len(n_dom), s = seq_len(n_sub))
+  pop$sub_id <- paste0("d", pop$d, "s", pop$s)
+  pop$x1 <- stats::rnorm(nrow(pop))
+  pop$x2 <- stats::runif(nrow(pop))
+  pop$popw <- stats::runif(nrow(pop), 5, 50)
+
+  smp <- pop[rep(seq_len(nrow(pop)), each = n_per), ]
+  smp$y <- 0.3 * smp$x1 + 0.5 * smp$x2 + stats::rnorm(nrow(smp), sd = 0.1)
+  smp$smpw <- stats::runif(nrow(smp), 1, 3)
+
+  cast <- switch(domain_type,
+                 integer   = function(v) as.integer(v),
+                 numeric   = function(v) as.numeric(v),
+                 character = function(v) as.character(v),
+                 factor    = function(v) factor(as.character(v)))
+  pop$dom <- cast(pop$d); smp$dom <- cast(smp$d)
+  list(pop = pop[, c("dom", "sub_id", "x1", "x2", "popw")],
+       smp = smp[, c("dom", "sub_id", "x1", "x2", "y", "smpw")])
+}
+
+fit_toy <- function(dat) {
+  povmap::xgb(fixed = y ~ x1 + x2,
+              smp_data = dat$smp, smp_weights = "smpw",
+              pop_data = dat$pop, pop_weights = "popw",
+              domains = "dom", sub_domains = "sub_id",
+              transformation = "no", bootstrap = FALSE,
+              nrounds = 5, seed = 1, benchmark_weights = "smpw")
+}
+
+test_that("xgb() accepts an integer domain identifier", {
+  fit <- fit_toy(make_toy("integer"))
+  expect_s3_class(fit, "xgb")
+  expect_equal(nrow(fit$ind), 6L)
+  expect_false(any(is.na(fit$ind$Mean)))
+})
+
+test_that("xgb() accepts a numeric domain identifier", {
+  fit <- fit_toy(make_toy("numeric"))
+  expect_equal(nrow(fit$ind), 6L)
+  expect_false(any(is.na(fit$ind$Mean)))
+})
+
+test_that("xgb() accepts a factor domain identifier", {
+  fit <- fit_toy(make_toy("factor"))
+  expect_equal(nrow(fit$ind), 6L)
+  expect_false(any(is.na(fit$ind$Mean)))
+})
+
+test_that("domain type does not change the point estimates", {
+  # the identifier's storage mode is bookkeeping; the numbers must not move
+  a <- fit_toy(make_toy("integer"))$ind
+  b <- fit_toy(make_toy("character"))$ind
+  a <- a[order(as.character(a$Domain)), ]
+  b <- b[order(as.character(b$Domain)), ]
+  expect_equal(a$Mean, b$Mean, tolerance = 1e-12)
+})


### PR DESCRIPTION
Fixes xgb() failing when you pass integer domain identifiers, despite the documentation saying numeric is allowed.

The mechanism is that xgb.R rebuilds the domain column from rownames(), which are always character, then joins it back onto the sample data. If you passed municipality codes as integers, the join errors with incompatible types. The fix restores the incoming type before the join, so as.numeric() for numeric, original levels for factors, character untouched.